### PR TITLE
Update to 10.0.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.22 AS tmp
 RUN --mount=type=cache,target=/var/cache/apk \
     apk add curl unzip
 
-ENV VERSION=8.1.31
+ENV VERSION=10.0.1
 RUN curl -sSL https://github.com/lensesio/stream-reactor/releases/download/${VERSION}/kafka-connect-aws-s3-${VERSION}.zip -o /tmp/kafka-connect-aws-s3.zip
 RUN unzip -d /tmp /tmp/kafka-connect-aws-s3.zip
 RUN mkdir -p /opt/lib


### PR DESCRIPTION
Putting this in master, as I found a way to migrate between the versions without restarting the whole backup and that is by removing the .indexes folder. With doing this, it will resume from the consumer group.